### PR TITLE
Use ArrayPool for encoding buffers in netstandard2.1

### DIFF
--- a/source/FileLogger/FileLoggerProcessor.cs
+++ b/source/FileLogger/FileLoggerProcessor.cs
@@ -474,7 +474,7 @@ namespace Karambolo.Extensions.Logging.File
                                 if (logFile.ShouldEnsurePreamble)
                                     await logFile.EnsurePreambleAsync(cancellationToken).ConfigureAwait(false);
 
-                                await logFile.WriteBytesAsync(logFile.Encoding.GetBytes(entry.Text), cancellationToken).ConfigureAwait(false);
+                                await logFile.WriteTextAsync(entry.Text, logFile.Encoding, cancellationToken).ConfigureAwait(false);
 
                                 if (logFile.AccessMode == LogFileAccessMode.KeepOpenAndAutoFlush)
                                     logFile.Flush();

--- a/source/FileLogger/FileLoggerProcessor.netstandard2.0.cs
+++ b/source/FileLogger/FileLoggerProcessor.netstandard2.0.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Karambolo.Extensions.Logging.File
@@ -7,6 +8,12 @@ namespace Karambolo.Extensions.Logging.File
     {
         protected internal partial class LogFileInfo
         {
+            internal Task WriteTextAsync(string text, Encoding encoding, CancellationToken cancellationToken)
+            {
+                var bytes = encoding.GetBytes(text);
+                return _appendStream.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
+            }
+
             internal Task WriteBytesAsync(byte[] bytes, CancellationToken cancellationToken)
             {
                 return _appendStream.WriteAsync(bytes, 0, bytes.Length, cancellationToken);

--- a/source/FileLogger/FileLoggerProcessor.netstandard2.1.cs
+++ b/source/FileLogger/FileLoggerProcessor.netstandard2.1.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading;
+﻿using System;
+using System.Buffers;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Karambolo.Extensions.Logging.File
@@ -7,9 +10,24 @@ namespace Karambolo.Extensions.Logging.File
     {
         protected internal partial class LogFileInfo
         {
-            internal ValueTask WriteBytesAsync(byte[] bytes, CancellationToken cancellationToken)
+            internal async ValueTask WriteTextAsync(string text, Encoding encoding, CancellationToken cancellationToken)
             {
-                return _appendStream.WriteAsync(bytes, cancellationToken);
+                var buffer = ArrayPool<byte>.Shared.Rent(encoding.GetMaxByteCount(text.Length));
+
+                try
+                {
+                    var byteCount = encoding.GetBytes(text, buffer);
+                    await _appendStream.WriteAsync(buffer.AsMemory(0, byteCount), cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            }
+
+            internal Task WriteBytesAsync(byte[] bytes, CancellationToken cancellationToken)
+            {
+                return _appendStream.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
             }
         }
     }


### PR DESCRIPTION
This removes byte[] allocations for writing each line, greatly reducing the byte[] allocation rate of the library.