### PR TITLE
Add regression tests for generic AddJsonFile named options (#39)

### DIFF
--- a/source/FileLogger.Json/JsonFileLoggerExtensions.cs
+++ b/source/FileLogger.Json/JsonFileLoggerExtensions.cs
@@ -99,11 +99,16 @@ public static partial class JsonFileLoggerExtensions
         Action<FileLoggerOptions>? configure = null, string? optionsName = null)
         where TProvider : FileLoggerProvider
     {
+        if (builder is null)
+            throw new ArgumentNullException(nameof(builder));
+
+        optionsName ??= typeof(TProvider).ToString();
+
         builder.AddFile<TProvider>(context, configure: null, optionsName)
-            .ConfigureTextBuilder(textBuilder ?? JsonFileLogEntryTextBuilder.Default, optionsName ?? typeof(TProvider).ToString());
+            .ConfigureTextBuilder(textBuilder ?? JsonFileLogEntryTextBuilder.Default, optionsName);
 
         if (configure is not null)
-            builder.Services.Configure(configure);
+            builder.Services.Configure(optionsName, configure);
 
         return builder;
     }
@@ -125,11 +130,16 @@ public static partial class JsonFileLoggerExtensions
         where TProvider : FileLoggerProvider
         where TOptions : FileLoggerOptions
     {
+        if (builder is null)
+            throw new ArgumentNullException(nameof(builder));
+
+        optionsName ??= typeof(TProvider).ToString();
+
         builder.AddFile<TProvider, TOptions>(context, configure: null, optionsName)
-            .ConfigureTextBuilder(textBuilder ?? JsonFileLogEntryTextBuilder.Default, optionsName ?? typeof(TProvider).ToString());
+            .ConfigureTextBuilder(textBuilder ?? JsonFileLogEntryTextBuilder.Default, optionsName);
 
         if (configure is not null)
-            builder.Services.Configure(configure);
+            builder.Services.Configure(optionsName, configure);
 
         return builder;
     }
@@ -145,11 +155,16 @@ public static partial class JsonFileLoggerExtensions
         where TProvider : FileLoggerProvider
         where TOptions : FileLoggerOptions
     {
+        if (builder is null)
+            throw new ArgumentNullException(nameof(builder));
+
+        optionsName ??= typeof(TProvider).ToString();
+
         builder.AddFile<TProvider, TOptions>(bindOptions, context, configure: null, optionsName)
-            .ConfigureTextBuilder(textBuilder ?? JsonFileLogEntryTextBuilder.Default, optionsName ?? typeof(TProvider).ToString());
+            .ConfigureTextBuilder(textBuilder ?? JsonFileLogEntryTextBuilder.Default, optionsName);
 
         if (configure is not null)
-            builder.Services.Configure(configure);
+            builder.Services.Configure(optionsName, configure);
 
         return builder;
     }

--- a/test/FileLogger.Test/SettingsTest.cs
+++ b/test/FileLogger.Test/SettingsTest.cs
@@ -381,4 +381,54 @@ public class SettingsTest
             ""
         }, lines);
     }
+
+    private static void AssertUserConfigurationAppliesToNamedOptions(
+        Action<ILoggingBuilder> configureLogging, string optionsName, string expectedBasePath)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(configureLogging);
+
+        using ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+        // The provider resolves its settings via IOptionsMonitor.Get(optionsName), so the user
+        // configuration callback must be applied to the named options instance, not Options.DefaultName.
+        IOptionsMonitor<FileLoggerOptions> optionsMonitor =
+            serviceProvider.GetRequiredService<IOptionsMonitor<FileLoggerOptions>>();
+
+        Assert.Equal(expectedBasePath, optionsMonitor.Get(optionsName).BasePath);
+        Assert.NotEqual(expectedBasePath, optionsMonitor.Get(Options.DefaultName).BasePath);
+    }
+
+    [Fact]
+    public void Issue39_GenericAddJsonFileAppliesUserConfigurationToNamedOptions()
+    {
+        const string optionsName = "MyJsonProvider";
+        const string basePath = "some-sentinel-base-path";
+
+        AssertUserConfigurationAppliesToNamedOptions(
+            lb => lb.AddJsonFile<OtherFileLoggerProvider>(configure: o => o.BasePath = basePath, optionsName: optionsName),
+            optionsName, basePath);
+    }
+
+    [Fact]
+    public void Issue39_GenericAddJsonFileWithOptionsAppliesUserConfigurationToNamedOptions()
+    {
+        const string optionsName = "MyJsonProvider";
+        const string basePath = "some-sentinel-base-path";
+
+        AssertUserConfigurationAppliesToNamedOptions(
+            lb => lb.AddJsonFile<OtherFileLoggerProvider, FileLoggerOptions>(configure: o => o.BasePath = basePath, optionsName: optionsName),
+            optionsName, basePath);
+    }
+
+    [Fact]
+    public void Issue39_GenericAddJsonFileWithBindOptionsAppliesUserConfigurationToNamedOptions()
+    {
+        const string optionsName = "MyJsonProvider";
+        const string basePath = "some-sentinel-base-path";
+
+        AssertUserConfigurationAppliesToNamedOptions(
+            lb => lb.AddJsonFile<OtherFileLoggerProvider, FileLoggerOptions>(bindOptions: (o, c) => { }, configure: o => o.BasePath = basePath, optionsName: optionsName),
+            optionsName, basePath);
+    }
 }


### PR DESCRIPTION
## Regression test for #39 (depends on #40)

Adds a regression test pinning the bug from #39: the generic `AddJsonFile<TProvider>` / `AddJsonFile<TProvider, TOptions>` overloads registered the user `configure` callback against `Options.DefaultName` instead of the named options instance the provider resolves via `IOptionsMonitor.Get(optionsName)`, so user configuration never reached the provider's own options.

### What this contains

This branch is **stacked on #40** (the fix), which isn't on `master` yet, so the diff currently shows two commits:

1. `d866c08` — the fix from #40 (base only; not my work)
2. the regression test (the actual contribution)

Once #40 merges into `master`, this PR reduces to just the test commit. If you'd prefer, the test can instead be folded directly into #40.

### Coverage

Three `[Fact]`s in `SettingsTest.cs`, one per affected overload:

- `AddJsonFile<TProvider>(configure:, optionsName:)`
- `AddJsonFile<TProvider, TOptions>(configure:, optionsName:)`
- `AddJsonFile<TProvider, TOptions>(bindOptions, configure:, optionsName:)`

Each builds the service provider, resolves `IOptionsMonitor<FileLoggerOptions>.Get(optionsName)`, and asserts the user-configured sentinel (`BasePath`) lands on the **named** instance and not on `Options.DefaultName`. `BasePath` is the sentinel rather than `RootPath` because `RootPath`'s setter eagerly constructs a `PhysicalFileAppender` that validates the directory on disk.

### Verification (net10.0)

- Fails against the pre-fix source — all three with `Assert.Equal` mismatches (`Expected "some-sentinel-base-path", Actual null`).
- Passes with #40's fix.
- Full suite green (18 passed, 2 platform-skipped).

Closes #39 once #40 is in.
